### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kiddom/go-onedrive-codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Managed by CODEOWNERS rollout
 * @kiddom/go-onedrive-codeowners


### PR DESCRIPTION
Create repo codeowners team, add top engineering contributors, and point CODEOWNERS to the team.